### PR TITLE
Update LogStream.php - Set default user-agent string

### DIFF
--- a/src/LogStream.php
+++ b/src/LogStream.php
@@ -105,7 +105,7 @@ final class LogStream
         string   $apiKey    = '',
         string   $apiToken  = '',
         ?Request $request   = null,
-        string   $userAgent = 'LogStream-PHP-Client/1.0',
+        string   $userAgent = Constants::USER_AGENT_VENDOR,
     ) {
         if (!in_array($authMode, [self::AUTH_BEARER, self::AUTH_API_KEY], true)) {
             throw new \InvalidArgumentException(


### PR DESCRIPTION
## 📑 Description
Update LogStream.php - Set default user-agent string

## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Enhancements:
- Standardize the default user-agent string to use a central Constants::USER_AGENT_VENDOR value.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated default User-Agent header configuration for improved maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->