### PR TITLE
refactor: replace `curl_close` with `unset` in Request class

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,5 +29,6 @@
         "CURLOPT",
         "httponly",
         "Packagist"
-    ]
+    ],
+    "snyk.advanced.autoSelectOrganization": true
 }

--- a/src/Request.php
+++ b/src/Request.php
@@ -189,7 +189,7 @@ class Request
         $responseContent = curl_exec($curl);
 
         $response = $this->handleResponse($responseContent, $curl, $fields[CURLOPT_URL]);
-        curl_close($curl);
+        unset($curl);
 
         return $response;
     }
@@ -265,7 +265,7 @@ class Request
             $responseContent = curl_multi_getcontent($curl);
             $responses[$key] = $this->handleResponse($responseContent, $curl, $this->multiRequests[$key][CURLOPT_URL]);
             curl_multi_remove_handle($multiCurl, $curl);
-            curl_close($curl);
+            unset($curl);
         }
 
         curl_multi_close($multiCurl);


### PR DESCRIPTION
## 📑 Description
Replace `curl_close` with `unset` for curl handles in `Request.php`. This change is aimed at ensuring the automatic cleanup of resources by PHP's garbage collector, streamlining handling of cURL handles. Additionally, enable Snyk's `autoSelectOrganization` in VSCode settings for improved security checks.


## ✅ Checks
- [X] My pull request adheres to the code style of this project
- [X] My code requires changes to the documentation
- [X] I have updated the documentation as required
- [X] All the tests have passed

## ☢️ Does this introduce a breaking change?
- [ ] Yes
- [X] No

---

## Summary by Sourcery

Refine cURL handle cleanup in the Request class and adjust local VS Code security tooling configuration.

Enhancements:
- Switch cURL handle teardown in Request::execute and Request::executeBatch from explicit closing to unsetting the handle to rely on PHP's garbage collection for cleanup.

Chores:
- Update VS Code workspace settings to enable Snyk's automatic organization selection for security scanning.